### PR TITLE
Add the ONTOLOGY_HOSTNAME param to the compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,11 @@ Mock KB (`/mockkb`) exposes a mock knowledge base on port 5001.
 > :point_right: Start by running the service using Docker ([README](mockkb/README.md)) and doing a GET request to `/kb/api/v1.0/waypoint`.
 
 
-# Ontology server
+## Ontology server
 
-Ontology server (`/ontology-server`) exposes named graphs in the [Cliopatria](http://cliopatria.swi-prolog.org/home) installation over HTTP in RDF format via Nginx server.
+Ontology server (`/ontology-server`) exposes named graphs in the [Cliopatria](http://cliopatria.swi-prolog.org/home) installation over HTTP in RDF format via an Nginx server.
 
-> :point_right: Start by:
->
-> * running the project using `docker-compose up` command
-> * logging into the Cliopatria instance via http://localhost:3020 using `admin` login and password that you got from Leo via Slack.
-> * Upload [pp.ttl](planner_reasoner/rdf/base/pp.ttl) into named graph `http://ontology.cf.ericsson.net/planning_problem` via the http://localhost:3020/user/loadFile
-> * Upload [warehouse_domain.ttl](planner_reasoner/rdf/base/warehouse_domain.ttl) into named graph `http://ontology.cf.ericsson.net/warehouse_domain` via the http://localhost:3020/user/loadFile
-> * Open http://localhost:80/warehouse_domain. Nginx should return the named graph with the URI `http://ontology.cf.ericsson.net/` (URI base) *plus* `warehouse_domain` (URI fragment from your request).
-
-> :fire: **Leo**, the last step is not working, I am getting *404 not found* (Andrew).
+> :point_right: Start by following the [Getting Started section](ontology-server/README.md#getting-started) in the README.
 
 
 ## Optic Docker

--- a/ontology-server/README.md
+++ b/ontology-server/README.md
@@ -1,0 +1,25 @@
+# Ontology server
+
+A docker-compose project that exposes named graphs in the [Cliopatria](http://cliopatria.swi-prolog.org/home) installation over HTTP in RDF format via an Nginx server.
+
+## Getting started
+
+1. Decide which hostname the nginx will run on. You can use `localhost` for the development or any other hostname that resolves to your machine's IP (run `hostname` to see your reverse PTR record, should be *blabla.ki.sw.ericsson.se*).
+1. Build the `nginx` image with the right hostname (if you omit the parameters, `localhost` will be used):
+
+  `docker-compose build --build-arg ONTOLOGY_HOSTNAME=localhost nginx`
+  
+1. Run the composed set of images:
+
+  `docker-compose up`
+
+1. Visit http://localhost:3020 to set up Cliopatria.
+1. visit `http://localhost/_suffix_`, to see the named graph contents.
+
+In the command above, `_suffix_` stands for the part of the named graph URI after the hostname: `http://_hostname_/_suffix_`. To configure Cliopatria:
+
+- Log into Cliopatria via http://localhost:3020 using `admin` login and password that you got from Leo via Slack.
+- Upload [pp.ttl](planner_reasoner/rdf/base/pp.ttl) into named graph `http://_hostname_/planning_problem` via the http://localhost:3020/user/loadFile
+- Upload [warehouse_domain.ttl](planner_reasoner/rdf/base/warehouse_domain.ttl) into named graph `http://_hostname_/warehouse_domain` via the http://localhost:3020/user/loadFile
+- Open http://localhost:80/warehouse_domain. Nginx should return the named graph with the URI `http://localhost/` (URI base, unless you used another hostname) *plus* `warehouse_domain` (URI fragment from your request).
+

--- a/ontology-server/docker-compose.yml
+++ b/ontology-server/docker-compose.yml
@@ -1,7 +1,11 @@
 version: '2'
 services:
   nginx:
-    build: ./nginx
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+      args:
+       - ONTOLOGY_HOSTNAME=localhost
     ports:
      - "80:80"
   cliopatria:

--- a/ontology-server/nginx/Dockerfile
+++ b/ontology-server/nginx/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -yq install nginx
 WORKDIR /etc/nginx/sites-available
 COPY cliopatria .
 RUN sed -i 's/%ONTOLOGY_HOSTNAME%/'"$ONTOLOGY_HOSTNAME"'/g' cliopatria
-RUN cat cliopatria
+# RUN cat cliopatria
 WORKDIR /etc/nginx/sites-enabled
 RUN ln -s /etc/nginx/sites-available/cliopatria .
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/ontology-server/nginx/Dockerfile
+++ b/ontology-server/nginx/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:16.04
 LABEL maintainer "leonid.mokrushin@ericsson.com"
 
+ARG ONTOLOGY_HOSTNAME
+
 # update/upgrade base system
 RUN apt-get update
 RUN apt-get -yq upgrade
@@ -11,6 +13,8 @@ RUN apt-get -yq install nginx
 # configure nginx
 WORKDIR /etc/nginx/sites-available
 COPY cliopatria .
+RUN sed -i 's/%ONTOLOGY_HOSTNAME%/'"$ONTOLOGY_HOSTNAME"'/g' cliopatria
+RUN cat cliopatria
 WORKDIR /etc/nginx/sites-enabled
 RUN ln -s /etc/nginx/sites-available/cliopatria .
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/ontology-server/nginx/cliopatria
+++ b/ontology-server/nginx/cliopatria
@@ -2,10 +2,10 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name ontology.cf.ericsson.net;
+    server_name %ONTOLOGY_HOSTNAME%;
 
     location / {
-      rewrite /(.*)      /api/export_graph?graph=http%3A%2F%2Fontology.cf.ericsson.net%2F$1&mimetype=text%2Fplain&format=rdfxml break;
+      rewrite /(.*)      /api/export_graph?graph=http%3A%2F%2F%ONTOLOGY_HOSTNAME%%2F$1&mimetype=text%2Fplain&format=rdfxml break;
       proxy_pass         http://cliopatria:3020;
       proxy_redirect     off;
       proxy_set_header   Host $host;


### PR DESCRIPTION
Allows to switch between the localhost and the deployment host during
the image build phase.

Closes #1 with help of @likelion.

Signed-off-by: Andrew Berezovskyi <andriib@kth.se>