### PR TITLE
Add the sample RDF w/o RDF lists

### DIFF
--- a/planner_reasoner/rdf/base/ordered_types.ttl
+++ b/planner_reasoner/rdf/base/ordered_types.ttl
@@ -1,0 +1,91 @@
+##############################################################################
+# We assume the following:
+# * the IEEE/Warehouse ontology cannot be modified (the latter we make up
+#      ourselves, but still we should keep it separate from the rest)
+# * we have defined the PDDL-specific classes and properties in the 'pp' domain
+# * we use RDF classes to model PDDL-specific elements that apply directly
+#      on the domain in a warehouse_planning domain, e.g. robot-grip-action.
+#      Actions are PDDL specific concepts, but robot gripper is a domain specific
+#      concept and we want to keep planner generic but have tight control over the
+#      definition of the robot-grip-action etc. (for MBSE purposes etc.)
+#
+# We actually model both action prototypes (definitions, e.g. "robot can grip a box")
+# and action invocations ("r1 grip b1") as instances, but then more modelling
+# and checks will move to the runtime.
+#
+##############################################################################
+
+
+
+##########################################################
+# This is defined at the design time and can be modified
+# at runtime if the warehouse configuration changes
+##########################################################
+
+warehouse_planning:robotMoveAction a rdfs:Class;
+    rdf:subClassOf pp:ActionDefinition;
+    rdfs:label "robot-moveto-waypoint"
+    pp:hasArgument _:robotMoveAction-a;
+    pp:hasArgument _:robotMoveAction-b;
+    pp:hasArgument _:robotMoveAction-c;
+    pp:hasArgument _:robotMoveAction-d .
+
+# these are blank nodes below
+
+_:robotMoveAction-a a pp:VariableDefinition;
+    rdfs:label "waypoint-src";
+    pp:variableType warehouse:Waypoint;
+    # this is what gives order in the action definition
+    sh:order "0".
+
+_:robotMoveAction-b a pp:VariableDefinition;
+    rdfs:label "waypoint-dst";
+    pp:variableType warehouse:Waypoint;
+    # this is what gives order in the action definition
+    sh:order "1".
+
+_:robotMoveAction-c a pp:VariableDefinition;
+    rdfs:label "robot";
+    pp:variableType ieee:Robot;
+    # this is what gives order in the action definition
+    sh:order "2".
+
+_:robotMoveAction-d a pp:VariableDefinition;
+    rdfs:label "speed";
+    pp:variableType xsd:float;
+    # this is what gives order in the action definition
+    sh:order "3".
+
+
+##########################################################
+# This is how the actually those definitions are used at runtime
+##########################################################
+
+
+# this is an RDF instance of the warehouse_planning:robotMoveAction class
+warehouse_planning:robotMoveAction1234 a warehouse_planning:robotMoveAction;
+    pp:withArgument _:robotMoveAction1234-a;
+    pp:withArgument _:robotMoveAction1234-b;
+    pp:withArgument _:robotMoveAction1234-c;
+    pp:withArgument _:robotMoveAction1234-d .
+
+_:robotMoveAction1234-a a VariableInstance;
+    rdfs:label "wp1";
+    pp:variable warehouse_planning:wpA01;
+    sh:order "0" .
+
+_:robotMoveAction1234-b a VariableInstance;
+    rdfs:label "wp2";
+    pp:variable warehouse_planning:wpC42;
+    sh:order "1" .
+
+_:robotMoveAction1234-c a VariableInstance;
+    rdfs:label "r1";
+    pp:variable warehouse_planning:robot123135;
+    sh:order "2" .
+
+_:robotMoveAction1234-c a VariableInstance;
+    rdfs:label "speed-r1";
+    pp:variable "12.45";
+    sh:order "3" .
+


### PR DESCRIPTION
This is a sample RDF file of how ordering will be differentiated between the variable types (fixed, see line 39 for examply) and variable instances (dynamic, will use a wrapper type to attach order property, eg line 85). As you can see in the line 84, we do not define order on the variable `robot123135` itself, but on a wrapping blank node that carries the variable for the "invocation".

