### PR TITLE
Reworked ontology declaration and loading procedures

### DIFF
--- a/oslc_prolog/config-available/oslc_prolog.pl
+++ b/oslc_prolog/config-available/oslc_prolog.pl
@@ -3,11 +3,17 @@
 /** <module> OSLC Prolog
 */
 
+%:- debug(http(send_request)).
+%:- debug(http(open)).
+%:- debug(rdf(load)).
+
 :- use_module(library(semweb/rdf_library)).
 
 :- rdf_attach_library(oslc_prolog(rdf)).
 :- rdf_load_library(oslc).
-:- rdf_load_library(oslc_shapes).
+
+:- use_module(library(oslc_ontology)).
+:- register_ontology(oslc_shapes).
 
 :- use_module(library(oslc)).
 :- use_module(library(oslc_core)).

--- a/oslc_prolog/config-available/oslc_prolog.pl
+++ b/oslc_prolog/config-available/oslc_prolog.pl
@@ -11,9 +11,7 @@
 
 :- rdf_attach_library(oslc_prolog(rdf)).
 :- rdf_load_library(oslc).
-
-:- use_module(library(oslc_ontology)).
-:- register_ontology(oslc_shapes).
+:- rdf_load_library(oslc_shapes).
 
 :- use_module(library(oslc)).
 :- use_module(library(oslc_core)).

--- a/oslc_prolog/lib/oslc.pl
+++ b/oslc_prolog/lib/oslc.pl
@@ -46,11 +46,9 @@
 
 :- rdf_meta rdfType(r).
 :- rdf_meta oslcInstanceShape(r).
-:- rdf_meta oslcInstanceShapeShape(r).
 
 rdfType(rdf:type).
 oslcInstanceShape(oslc:instanceShape).
-oslcInstanceShapeShape(oslc_shapes:oslcInstanceShape).
 
 check_iri(NS:Local, IRI) :- !,
   must_be(atom, NS),
@@ -85,7 +83,7 @@ create_resource(IRI, Types, Shapes, Properties, Sink) :-
     delete_resource(Id, Sink),
     rdfType(RT),
     marshal_list_property(Id, RT, Types, _, Sink),
-    oslcInstanceShapeShape(IOSS),
+    rdf_global_id(oslc_shapes:oslcInstanceShape, IOSS),
     check_property(Id, IOSS, _, Shapes, _),
     oslcInstanceShape(OIS),
     marshal_list_property(Id, OIS, Shapes, _, Sink),

--- a/oslc_prolog/lib/oslc.plt
+++ b/oslc_prolog/lib/oslc.plt
@@ -7,11 +7,10 @@
 :- use_module(library(semweb/rdf_library)).
 :- use_module(library(oslc)).
 
-:- rdf_meta assertion(r,t).
-
-:- rdf_register_prefix(tests, 'http://ontology.cf.ericsson.net/tests/').
 :- rdf_attach_library(oslc_prolog(rdf)).
 :- rdf_load_library(tests).
+
+:- rdf_meta assertion(r,t).
 
 assertion(Actual, Expected) :-
   assertion(Actual == Expected).

--- a/oslc_prolog/lib/oslc_core.pl
+++ b/oslc_prolog/lib/oslc_core.pl
@@ -30,7 +30,10 @@ get_time_class(Context) :-
 handle_ontology(Context) :-
   once((
     rdf_graph(Graph),
-    atom_concat(Graph, _, Context.iri)
+    once((
+      atom_concat(Graph, '/', Context.iri)
+    ; atom_concat(Graph, '#', Context.iri)
+    ))
   )),
   Context.graph_out = Graph.
 

--- a/oslc_prolog/lib/oslc_core.pl
+++ b/oslc_prolog/lib/oslc_core.pl
@@ -87,8 +87,12 @@ post_resource(IRI, Source, Sink) :-
     )),
     copy_resource(NewResource, NewResource, Source, Sink, []),
     setting(oslc_prolog_server:base_uri, BaseUri),
+    uri_components(BaseUri, uri_components(C1, C2, PrefixPath, C4, C5)),
+    split_string(PrefixPath, "/", "/", Parts),
     rdf_global_id(Prefix:Name, NewResource),
-    atomic_list_concat([BaseUri, Prefix, '/', Name],  Location),
+    append(Parts, [Prefix, Name], NewParts),
+    atomics_to_string(NewParts, '/', NewPath),
+    uri_components(Location, uri_components(C1, C2, NewPath, C4, C5)),
     response(201, ['Location'(Location)]) % created
   ),
     oslc_error(Message),

--- a/oslc_prolog/lib/oslc_ontology.pl
+++ b/oslc_prolog/lib/oslc_ontology.pl
@@ -20,15 +20,18 @@ register_ontology(Ontology) :-
 %   under NewBaseURI.
 
 reload_ontologies(OldBaseURI, NewBaseURI) :-
-  forall(oslc_ontology:ontology(Ontology), (
-    ( nonvar(OldBaseURI)
-    -> atom_concat(OldBaseURI, Ontology, OldBaseName),
-       rdf_unload_graph(OldBaseName)
-    ; true
-    ),
-    atom_concat(NewBaseURI, Ontology, BaseName),
-    atom_concat(BaseName, '#', Source), % the named graph will have name without #
-    rdf_load_library(Ontology, [claimed_source(Source)]),
-    atom_concat(BaseName, '/', PrefixURI), % newly registered prefix always ends with /
-    rdf_register_prefix(Ontology, PrefixURI, [force(true)])
-  )).
+  ( current_predicate(oslc_ontology:ontology/1)
+  -> forall(oslc_ontology:ontology(Ontology), (
+       ( nonvar(OldBaseURI)
+       -> atom_concat(OldBaseURI, Ontology, OldBaseName),
+          rdf_unload_graph(OldBaseName)
+       ; true
+       ),
+       atom_concat(NewBaseURI, Ontology, BaseName),
+       atom_concat(BaseName, '#', Source), % the named graph will have name without #
+       rdf_load_library(Ontology, [claimed_source(Source)]),
+       atom_concat(BaseName, '/', PrefixURI), % newly registered prefix always ends with /
+       rdf_register_prefix(Ontology, PrefixURI, [force(true)])
+     ))
+  ; true
+  ).

--- a/oslc_prolog/lib/oslc_ontology.pl
+++ b/oslc_prolog/lib/oslc_ontology.pl
@@ -11,7 +11,7 @@
 %   managed by the OSLC server under URI having form of <BaseURI>/<Ontology>.
 
 register_ontology(Ontology) :-
-  assertz(oslc_ontology:ontology(Ontology)).
+  assertz(ontology(Ontology)).
 
 %!  reload_ontologies(+OldBaseURI, +NewBaseURI) is det.
 %
@@ -20,8 +20,8 @@ register_ontology(Ontology) :-
 %   under NewBaseURI.
 
 reload_ontologies(OldBaseURI, NewBaseURI) :-
-  ( current_predicate(oslc_ontology:ontology/1)
-  -> forall(oslc_ontology:ontology(Ontology), (
+  ( current_predicate(ontology/1)
+  -> forall(ontology(Ontology), (
        ( nonvar(OldBaseURI)
        -> atom_concat(OldBaseURI, Ontology, OldBaseName),
           rdf_unload_graph(OldBaseName)

--- a/oslc_prolog/lib/oslc_ontology.pl
+++ b/oslc_prolog/lib/oslc_ontology.pl
@@ -1,0 +1,34 @@
+:- module(oslc_ontology, [
+  register_ontology/1,
+  reload_ontologies/2
+]).
+
+:- use_module(library(semweb/rdf_library)).
+
+%!  register_ontology(+Ontology) is det.
+%
+%   Register Ontology (using Ontology as identifier from in Manifest.ttl) to be
+%   managed by the OSLC server under URI having form of <BaseURI>/<Ontology>.
+
+register_ontology(Ontology) :-
+  assertz(oslc_ontology:ontology(Ontology)).
+
+%!  reload_ontologies(+OldBaseURI, +NewBaseURI) is det.
+%
+%   Unloads managed ontologies from OldBaseURI and unregisters corresponding
+%   prefixes, and then loads these ontologies and registers new prefixes
+%   under NewBaseURI.
+
+reload_ontologies(OldBaseURI, NewBaseURI) :-
+  forall(oslc_ontology:ontology(Ontology), (
+    ( nonvar(OldBaseURI)
+    -> atom_concat(OldBaseURI, Ontology, OldBaseName),
+       rdf_unload_graph(OldBaseName)
+    ; true
+    ),
+    atom_concat(NewBaseURI, Ontology, BaseName),
+    atom_concat(BaseName, '#', Source), % the named graph will have name without #
+    rdf_load_library(Ontology, [claimed_source(Source)]),
+    atom_concat(BaseName, '/', PrefixURI), % newly registered prefix always ends with /
+    rdf_register_prefix(Ontology, PrefixURI, [force(true)])
+  )).

--- a/oslc_prolog/rdf/base/Manifest.ttl
+++ b/oslc_prolog/rdf/base/Manifest.ttl
@@ -3,12 +3,10 @@
 @prefix	dcterms: <http://purl.org/dc/terms/> .
 @prefix	oslc: <http://open-services.net/ns/core#> .
 
-<oslc>
-	a lib:Schema ;
-	a lib:Virtual ;
+<oslc.rdf>
+	a lib:Ontology ;
 	dcterms:title "All vocabulary URIs defined in the OSLC Core namespace"^^rdf:XMLLiteral ;
-	lib:source oslc: ;
-	lib:schema <oslc.rdf> .
+	lib:source oslc: .
 
 [ a lib:Namespace ;
 	lib:mnemonic "oslc" ;
@@ -17,9 +15,20 @@
 
 <oslc_shapes.ttl>
 	a lib:Ontology ;
-	dcterms:title "OSLC resource shapes"^^rdf:XMLLiteral .
+	dcterms:title "OSLC resource shapes"^^rdf:XMLLiteral ;
+	lib:source <http://ontology.cf.ericsson.net/oslc_shapes#> .
+
+[ a lib:Namespace ;
+	lib:mnemonic "oslc_shapes" ;
+	lib:namespace <http://ontology.cf.ericsson.net/oslc_shapes/>
+] .
 
 <tests.ttl>
 	a lib:Ontology ;
 	dcterms:title "Resources used in unit tests"^^rdf:XMLLiteral ;
 	lib:source <http://ontology.cf.ericsson.net/tests#> .
+
+[ a lib:Namespace ;
+	lib:mnemonic "tests" ;
+	lib:namespace <http://ontology.cf.ericsson.net/tests/>
+] .

--- a/oslc_prolog/rdf/base/Manifest.ttl
+++ b/oslc_prolog/rdf/base/Manifest.ttl
@@ -2,8 +2,6 @@
 @prefix	rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix	dcterms: <http://purl.org/dc/terms/> .
 @prefix	oslc: <http://open-services.net/ns/core#> .
-@prefix	oslc_shapes: <http://ontology.cf.ericsson.net/oslc_shapes/> .
-@prefix	tests: <http://ontology.cf.ericsson.net/tests/> .
 
 <oslc>
 	a lib:Schema ;
@@ -17,21 +15,11 @@
 	lib:namespace oslc:
 ] .
 
-<oslc_shapes>
-	a lib:Schema ;
-	a lib:Virtual ;
-	dcterms:title "OSLC resource shapes"^^rdf:XMLLiteral ;
-	lib:source <http://ontology.cf.ericsson.net/oslc_shapes#> ;
-	lib:schema <oslc_shapes.ttl> .
+<oslc_shapes.ttl>
+	a lib:Ontology ;
+	dcterms:title "OSLC resource shapes"^^rdf:XMLLiteral .
 
-[ a lib:Namespace ;
-	lib:mnemonic "oslc_shapes" ;
-	lib:namespace oslc_shapes:
-] .
-
-<tests>
-	a lib:Schema ;
-	a lib:Virtual ;
+<tests.ttl>
+	a lib:Ontology ;
 	dcterms:title "Resources used in unit tests"^^rdf:XMLLiteral ;
-	lib:source <http://ontology.cf.ericsson.net/tests#> ;
-	lib:schema <tests.ttl> .
+	lib:source <http://ontology.cf.ericsson.net/tests#> .

--- a/oslc_prolog/rdf/base/oslc_shapes.ttl
+++ b/oslc_prolog/rdf/base/oslc_shapes.ttl
@@ -3,8 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix	oslc: <http://open-services.net/ns/core#> .
-@prefix	: <http://ontology.cf.ericsson.net/oslc_shapes/> .
-@base	<http://ontology.cf.ericsson.net/oslc_shapes> .
+@prefix	: <oslc_shapes/> .
 
 # ======== Properties
 

--- a/oslc_prolog/rdf/base/oslc_shapes.ttl
+++ b/oslc_prolog/rdf/base/oslc_shapes.ttl
@@ -3,7 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix	oslc: <http://open-services.net/ns/core#> .
-@prefix	: <oslc_shapes/> .
+@prefix	: <http://ontology.cf.ericsson.net/oslc_shapes/> .
 
 # ======== Properties
 

--- a/oslc_prolog/rdf/base/tests.ttl
+++ b/oslc_prolog/rdf/base/tests.ttl
@@ -4,7 +4,6 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix	oslc: <http://open-services.net/ns/core#> .
-@prefix	oslc_shapes: <http://ontology.cf.ericsson.net/oslc_shapes/> .
 @prefix	: <http://ontology.cf.ericsson.net/tests/> .
 @base	<http://ontology.cf.ericsson.net/tests> .
 

--- a/oslc_prolog/rdf/cpack/oslc_prolog.ttl
+++ b/oslc_prolog/rdf/cpack/oslc_prolog.ttl
@@ -4,25 +4,14 @@
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
 @prefix cpack:   <http://cliopatria.swi-prolog.org/schema/cpack#> .
 
-# This file is a Turtle-format RDF file that describes the package.  It
-# *must* be located in rdf/cpack/oslc_prolog.ttl
-#
-# Author is a FOAF Person. If you have a FOAF profile, you can link to
-# this.  Otherwise you can specify the information inline as done below.
-# See http://xmlns.com/foaf/spec/ for defines fields.
-
 <> a cpack:Library ;
-	cpack:packageName "oslc_prolog" ;
-	dcterms:title "OSLC Prolog" ;
-	cpack:author [ a foaf:Person ;
-		       foaf:name "Leonid Mokrushin" ;
-		       foaf:mbox <leonid.mokrushin@ericsson.com> ;
-		     ] ;
-	cpack:primaryRepository
-	    [ a cpack:GitRepository ;
-	      cpack:gitURL <ssh://gitolite@openalm.lmera.ericsson.se/scott/scott.git>
-	    ] ;
-	cpack:description
-
-"""This is an implementation of OSLC in Prolog.
-""" .
+  cpack:packageName "oslc_prolog" ;
+  dcterms:title "Implementation of OSCL Core 2.0" ;
+  cpack:author [ a foaf:Person ;
+                 foaf:name "Leonid Mokrushin" ;
+                 foaf:mbox <leonid.mokrushin@ericsson.com> ;
+               ] ;
+  cpack:primaryRepository [ a cpack:GitRepository ;
+                            cpack:gitURL <https://github.com/EricssonResearch/scott-eu.git>
+                          ] ;
+  cpack:description "This is an implementation of OSLC Core 2.0" .

--- a/planner_reasoner/config-available/planner_reasoner.pl
+++ b/planner_reasoner/config-available/planner_reasoner.pl
@@ -3,6 +3,14 @@
 /** <module> Planner Reasoner
 */
 
+:- use_module(library(semweb/rdf_library)).
+:- rdf_attach_library(planner_reasoner(rdf)).
+
+:- rdf_load_library(pp).
+:- rdf_load_library(pp_shapes).
+:- rdf_load_library(warehouse_domain).
+:- rdf_load_library(warehouse_problem).
+
 :- use_module(library(planner_reasoner)).
 
 %:- use_module(planner_reasoner(applications/planner_reasoner_server), []).

--- a/planner_reasoner/lib/planner_reasoner.pl
+++ b/planner_reasoner/lib/planner_reasoner.pl
@@ -3,16 +3,21 @@
 ]).
 
 :- use_module(library(semweb/rdf11)).
-:- use_module(library(semweb/rdf_library)).
-
-:- rdf_attach_library(planner_reasoner(rdf)).
-:- rdf_load_library(pp).
-:- rdf_load_library(wd).
-:- rdf_load_library(ppos).
-:- rdf_load_library(wp).
+:- use_module(library(oslc_dispatch)).
+:- use_module(library(oslc_rdf)).
+:- use_module(library(oslc)).
 
 :- rdf_meta generate_pddl(r, -).
 :- rdf_meta generate_pddl(r, r, -, -).
+
+:- oslc_get(pp:'Action', handle_action).
+
+handle_action(Context) :-
+  make_temp_graph(Context.graph_out),
+  forall(
+    member(Obj, [pp:'Action', pp:'Precondition', pp:'Effect']),
+    copy_resource(Obj, Obj, rdf, rdf(Context.graph_out), [])
+  ).
 
 generate_pddl(Resource, Out) :-
   rdf(Resource, rdf:type, Type),

--- a/planner_reasoner/rdf/base/Manifest.ttl
+++ b/planner_reasoner/rdf/base/Manifest.ttl
@@ -1,55 +1,35 @@
 @prefix	lib: <http://www.swi-prolog.org/rdf/library/> .
 @prefix	rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix	dcterms: <http://purl.org/dc/terms/> .
-@prefix	pp: <http://ontology.cf.ericsson.net/planning_ontology/> .
-@prefix	wd: <http://ontology.cf.ericsson.net/warehouse_domain/> .
-@prefix	wp: <http://ontology.cf.ericsson.net/warehouse_problem/> .
-@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
 
-<ppos>
-	a lib:Schema ;
-	a lib:Virtual ;
-	dcterms:title "Vocabulary of OSLC shapes describing resources that can be used in PDDL"^^rdf:XMLLiteral ;
-	lib:source <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes#> ;
-	lib:schema <pp_oslc_shapes.ttl> .
-
-[ a lib:Namespace ;
-	lib:mnemonic "ppos" ;
-	lib:namespace ppos:
-] .
-
-<pp>
-	a lib:Schema ;
-	a lib:Virtual ;
+<pp.ttl>
+	a lib:Ontology ;
 	dcterms:title "Vocabulary of class relations between PDDL resources"^^rdf:XMLLiteral ;
 	lib:source <http://ontology.cf.ericsson.net/planning_ontology#> ;
-	lib:schema <pp.ttl> .
-
-[ a lib:Namespace ;
+	a lib:Namespace ;
 	lib:mnemonic "pp" ;
-	lib:namespace pp:
-] .
+	lib:namespace <http://ontology.cf.ericsson.net/planning_ontology/> .
 
-<wd>
+<pp_shapes.ttl>
+	a lib:Ontology ;
+	dcterms:title "Vocabulary of OSLC shapes describing resources that can be used in PDDL"^^rdf:XMLLiteral ;
+	lib:source <http://ontology.cf.ericsson.net/planning_ontology_shapes#> ;
+	a lib:Namespace ;
+	lib:mnemonic "ppos" ;
+	lib:namespace <http://ontology.cf.ericsson.net/planning_ontology_shapes/> .
+
+<warehouse_domain.ttl>
 	a lib:Instances ;
-	a lib:Virtual ;
 	dcterms:title "Sample planning PDDL domain"^^rdf:XMLLiteral ;
 	lib:source <http://ontology.cf.ericsson.net/warehouse_domain#> ;
-	lib:schema <warehouse_domain.ttl> .
-
-[ a lib:Namespace ;
+	a lib:Namespace ;
 	lib:mnemonic "wd" ;
-	lib:namespace wd:
-] .
+	lib:namespace <http://ontology.cf.ericsson.net/warehouse_domain/> .
 
-<wp>
+<warehouse_problem.ttl>
 	a lib:Instances ;
-	a lib:Virtual ;
 	dcterms:title "Sample planning PDDL problem"^^rdf:XMLLiteral ;
 	lib:source <http://ontology.cf.ericsson.net/warehouse_problem#> ;
-	lib:schema <warehouse_problem.ttl> .
-
-[ a lib:Namespace ;
+  a lib:Namespace ;
 	lib:mnemonic "wp" ;
-	lib:namespace wp:
-] .
+	lib:namespace <http://ontology.cf.ericsson.net/warehouse_problem/> .

--- a/planner_reasoner/rdf/base/pp.ttl
+++ b/planner_reasoner/rdf/base/pp.ttl
@@ -1,13 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix oslc: <http://open-services.net/ns/core#> .
-@prefix sh: <http://www.w3.org/ns/shacl#> . # shapes constraint languge SHACL
-@prefix pp: <http://ontology.cf.ericsson.net/planning_ontology/> .
-@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
-@prefix wd: <http://ontology.cf.ericsson.net/warehouse_domain/> .
 @prefix : <http://ontology.cf.ericsson.net/planning_ontology/> .
-@base <http://ontology.cf.ericsson.net/planning_ontology> .
 
 #studied from the bnf specification of PDDL 2.1. https://www.jair.org/media/1129/live-1129-2132-jair.pdf without durative actions
 

--- a/planner_reasoner/rdf/base/pp_shapes.ttl
+++ b/planner_reasoner/rdf/base/pp_shapes.ttl
@@ -9,11 +9,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix oslc: <http://open-services.net/ns/core#> . #oslc core
 @prefix sh: <http://www.w3.org/ns/shacl#> . # shapes constraint languge SHACL
-@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
 @prefix pp: <http://ontology.cf.ericsson.net/planning_ontology/> .
-@prefix wd: <http://ontology.cf.ericsson.net/warehouse_domain_and_problem/> .
-@prefix : <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
-@base <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes> .
+@prefix : <http://ontology.cf.ericsson.net/planning_ontology_shapes/> .
 
 :OrderedArgumentShape
   a oslc:ResourceShape ;

--- a/planner_reasoner/rdf/base/warehouse_domain.ttl
+++ b/planner_reasoner/rdf/base/warehouse_domain.ttl
@@ -1,15 +1,10 @@
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix oslc: <http://open-services.net/ns/core#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> . # shapes constraint languge SHACL
 @prefix warehouse: <http://example.com/warehouse_ontology/> . #this should be later replaced by some ontology (ies) for robotics, or internal logistics
 @prefix pp: <http://ontology.cf.ericsson.net/planning_ontology/> .
-@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
-@prefix wd: <http://ontology.cf.ericsson.net/warehouse_domain/> .
-@prefix wp: <http://ontology.cf.ericsson.net/warehouse_problem/> .
+@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_shapes/> .
 @prefix : <http://ontology.cf.ericsson.net/warehouse_domain/> .
-@base <http://ontology.cf.ericsson.net/warehouse_domain> .
 
 ##############################################################################
 # all the types used in the domain file

--- a/planner_reasoner/rdf/base/warehouse_problem.ttl
+++ b/planner_reasoner/rdf/base/warehouse_problem.ttl
@@ -1,15 +1,7 @@
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix oslc: <http://open-services.net/ns/core#> .
-@prefix sh: <http://www.w3.org/ns/shacl#> . # shapes constraint languge SHACL
 @prefix warehouse: <http://example.com/warehouse_ontology/> . #this should be later replaced by some ontology (ies) for robotics, or internal logistics
 @prefix pp: <http://ontology.cf.ericsson.net/planning_ontology/> .
-@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_oslc_shapes/> .
-@prefix wd: <http://ontology.cf.ericsson.net/warehouse_domain/> .
-@prefix wp: <http://ontology.cf.ericsson.net/warehouse_problem/> .
+@prefix ppos: <http://ontology.cf.ericsson.net/planning_ontology_shapes/> .
 @prefix : <http://ontology.cf.ericsson.net/warehouse_problem/> .
-@base <http://ontology.cf.ericsson.net/warehouse_problem> .
 
 # all the types used in the domain file
 warehouse:Robot

--- a/planner_reasoner/rdf/cpack/planner_reasoner.ttl
+++ b/planner_reasoner/rdf/cpack/planner_reasoner.ttl
@@ -4,30 +4,18 @@
 @prefix foaf:    <http://xmlns.com/foaf/0.1/> .
 @prefix cpack:   <http://cliopatria.swi-prolog.org/schema/cpack#> .
 
-# This file is a Turtle-format RDF file that describes the package.  It
-# *must* be located in rdf/cpack/planner_reasoner.ttl
-#
-# Author is a FOAF Person. If you have a FOAF profile, you can link to
-# this.  Otherwise you can specify the information inline as done below.
-# See http://xmlns.com/foaf/spec/ for defines fields.
-
 <> a cpack:Library ;
-	cpack:packageName "planner_reasoner" ;
-	dcterms:title "Planner Reasoner" ;
-	cpack:author [ a foaf:Person ;
-		       foaf:name "Leonid Mokrushin" ;
-		       foaf:mbox <leonid.mokrushin@ericsson.com> ;
-		     ] ,
-				 [ a foaf:Person ;
-			 		 foaf:name "Aneta Vulgarakis Feljan" ;
-			 		 foaf:mbox <aneta.vulgarakis@ericsson.com> ;
-			 	 ] .
-
-	cpack:primaryRepository
-	    [ a cpack:GitRepository ;
-	      cpack:gitURL <ssh://gitolite@openalm.lmera.ericsson.se/scott/scott.git>
-	    ] ;
-	cpack:description
-
-"""This is an implementation of Planner Reasoner in Prolog.
-""" .
+  cpack:packageName "planner_reasoner" ;
+  dcterms:title "Planner Reasoner" ;
+  cpack:author [ a foaf:Person ;
+                 foaf:name "Leonid Mokrushin" ;
+                 foaf:mbox <leonid.mokrushin@ericsson.com> ;
+               ] ,
+               [ a foaf:Person ;
+                  foaf:name "Aneta Vulgarakis Feljan" ;
+                  foaf:mbox <aneta.vulgarakis@ericsson.com> ;
+                ] ;
+  cpack:primaryRepository [ a cpack:GitRepository ;
+                            cpack:gitURL <https://github.com/EricssonResearch/scott-eu.git>
+                          ] ;
+  cpack:description "This is an implementation of Planner Reasoner" .


### PR DESCRIPTION
Implemented managed ontologies. When a managed ontology is loaded by an OSLC server, its URI, Prefix and named graph are computed from the Base URI of that OSLC server (can be configured in ClioPatria via `Admin->Settings->oslc_prolog_server->Base URI`). This allows to deploy an ontology on different hosts without modifying the ontology file itself since managed ontology declaration is host independent. In this case ontology becomes dynamic, so it is not possible to use term expansion for prefixes in the code, instead one should use predicate `rdf_global_id` to resolve prefixed names into full IRIs. Managed ontology should use the following declaration of its prefix:

```
@prefix	: <my_ontology/> .
```

Relative path should be the prefix name with slash (/) at the end. To make an ontology managed, use `register_ontology/1` predicate when loading your CPACK instead of `rdf_load_library/1`. All managed ontologies are automatically reloaded and reregistered with new prefixes at run-time (hot swap) when the Base URI setting of the OSLC server is modified.