### PR TITLE
Set CPACK loading priority

### DIFF
--- a/oslc_prolog/config-available/500-oslc_prolog.pl
+++ b/oslc_prolog/config-available/500-oslc_prolog.pl
@@ -14,19 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-:- module(conf_planner_reasoner, []).
+:- module('500-oslc_prolog', []).
 
-/** <module> Planner Reasoner
+/** <module> OSLC Prolog
 */
 
+%:- debug(http(send_request)).
+%:- debug(http(open)).
+%:- debug(rdf(load)).
+
 :- use_module(library(semweb/rdf_library)).
-:- rdf_attach_library(planner_reasoner(rdf)).
 
-:- rdf_load_library(pddl).
-:- rdf_load_library(planner).
-:- rdf_load_library(pddl_example).
+:- rdf_attach_library(oslc_prolog(rdf)).
+:- rdf_load_library(oslc).
+:- rdf_load_library(oslc_shapes).
 
-:- use_module(library(pddl_generator)).
-:- use_module(library(metric_ff)).
+:- use_module(library(oslc)).
+:- use_module(library(oslc_core)).
 
-:- use_module(planner_reasoner(applications/planner_reasoner_server), []).
+:- use_module(oslc_prolog(applications/oslc_prolog_server)).
+:- use_module(oslc_prolog(applications/oslc_cliopatria_ui)).

--- a/oslc_prolog/config-available/DEFAULTS
+++ b/oslc_prolog/config-available/DEFAULTS
@@ -1,1 +1,1 @@
-config(oslc_prolog, link).
+config('500-oslc_prolog', link).

--- a/oslc_prolog/lib/oslc.pl
+++ b/oslc_prolog/lib/oslc.pl
@@ -124,10 +124,7 @@ applicable_shapes(Types, Shapes) :-
   findall(ResourceShape, (
     member(Type, Types),
     rdf(ResourceShape, rdf:type, oslc:'ResourceShape'),
-    once((
-      \+ rdf(ResourceShape, oslc:describes, _)
-    ; rdf(ResourceShape, oslc:describes, Type)
-    ))
+    rdf(ResourceShape, oslc:describes, Type)
   ), Shapes).
 
 create_shapes_dict(Shapes, Dict) :-

--- a/planner_reasoner/config-available/700-planner_reasoner.pl
+++ b/planner_reasoner/config-available/700-planner_reasoner.pl
@@ -14,23 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-:- module(conf_oslc_prolog, []).
+:- module('700-planner_reasoner', []).
 
-/** <module> OSLC Prolog
+/** <module> Planner Reasoner
 */
 
-%:- debug(http(send_request)).
-%:- debug(http(open)).
-%:- debug(rdf(load)).
-
 :- use_module(library(semweb/rdf_library)).
+:- rdf_attach_library(planner_reasoner(rdf)).
 
-:- rdf_attach_library(oslc_prolog(rdf)).
-:- rdf_load_library(oslc).
-:- rdf_load_library(oslc_shapes).
+:- rdf_load_library(pddl).
+:- rdf_load_library(planner).
+:- rdf_load_library(pddl_example).
 
-:- use_module(library(oslc)).
-:- use_module(library(oslc_core)).
+:- use_module(library(pddl_generator)).
+:- use_module(library(metric_ff)).
 
-:- use_module(oslc_prolog(applications/oslc_prolog_server)).
-:- use_module(oslc_prolog(applications/oslc_cliopatria_ui)).
+:- use_module(planner_reasoner(applications/planner_reasoner_server), []).

--- a/planner_reasoner/config-available/DEFAULTS
+++ b/planner_reasoner/config-available/DEFAULTS
@@ -1,0 +1,1 @@
+config('700-planner_reasoner', link).


### PR DESCRIPTION
When multiple dependent CPACKs are loaded the priority of loading is important. It is ensured by sorting of the config file names.