### PR TITLE
Put 'oslc.' options in the request context (for reuse purposes)

### DIFF
--- a/oslc_prolog/applications/oslc_prolog_server.pl
+++ b/oslc_prolog/applications/oslc_prolog_server.pl
@@ -138,10 +138,13 @@ format_response_graph(StatusCode, Graph, Headers, ContentType) :-
   must_be(ground, Graph),
   must_be(ground, ContentType),
   format(atom(ContentTypeValue), '~w; charset=utf-8', [ContentType]),
-  graph_md5(Graph, Hash),
-  append(Headers, ['ETag'(Hash), 'Content-type'(ContentTypeValue)], NewHeaders),
-  response(StatusCode, NewHeaders),
   oslc_dispatch:serializer(ContentType, Serializer), % select proper serializer
+  ( memberchk(Serializer, [rdf, turtle])
+  -> graph_md5(Graph, Hash),
+     append(Headers, ['ETag'(Hash), 'Content-type'(ContentTypeValue)], NewHeaders)
+  ; append(Headers, ['Content-type'(ContentTypeValue)], NewHeaders)
+  ),
+  response(StatusCode, NewHeaders),
   current_output(Out),
   oslc_dispatch:serialize_response(Out, Graph, Serializer). % serialize temporary RDF graph to the response
 

--- a/oslc_prolog/applications/oslc_prolog_server.pl
+++ b/oslc_prolog/applications/oslc_prolog_server.pl
@@ -87,6 +87,14 @@ dispatcher0(Request) :-
   -> read_request_body(Request, GraphIn)
   ; true
   ),
+  ( member(search(Search), Request),
+    findall(Option, (
+      member(Key=Value, Search),
+      atom_concat('oslc.', OP, Key),
+      Option =.. [OP, Value]
+    ), Options)
+  ; Options = []
+  ),
   once((
     dispatch(_{ request: Request,
                iri_spec: Prefix:ResourceSegments,
@@ -94,7 +102,8 @@ dispatcher0(Request) :-
            content_type: ContentType,
                graph_in: GraphIn,
               graph_out: GraphOut,
-                headers: Headers }), % main dispatch method
+                headers: Headers,
+                options: Options }), % main dispatch method
     ( ground(GraphOut),
       rdf_graph_property(GraphOut, triples(Triples)),
       Triples > 0 % the output document is not empty

--- a/oslc_prolog/lib/oslc_core.pl
+++ b/oslc_prolog/lib/oslc_core.pl
@@ -74,12 +74,6 @@ handle_get(Context) :-
   once(rdf(IRI, _, _)),
   once((
     member(search(Search), Context.request),
-    findall(Option, (
-        member(Key=Value, Search),
-        atom_concat('oslc.', OP, Key),
-        Option =.. [OP, Value]
-      ), Options
-    ),
     L1 = [],
     ( member(rdfs=sup, Search)
     -> findall(SuperClass, (
@@ -114,11 +108,10 @@ handle_get(Context) :-
     ; L5 = L4
     ),
     list_to_set(L5, Set)
-  ; Options = [],
-    Set = []
+  ; Set = []
   )),
   catch((
-    copy_resource([IRI|Set], [IRI|Set], rdf, tmp(Context.graph_out), [inline(rdf)|Options])
+    copy_resource([IRI|Set], [IRI|Set], rdf, tmp(Context.graph_out), [inline(rdf)|Context.options])
   ),
     oslc_error(Message),
     throw(response(400, Message)) % bad request (problem with Options)


### PR DESCRIPTION
Many query implementations may benefit from support of `olsc.properties` and `oslc.prefix` options, thus having them in the request context allows to reduce amount of code in the application and avoid duplicate code. The `Context.options` can be directly used in the `oslc:copy_resource/5` (see example usage in `oslc_core.pl` of this pull request).