### PR TITLE
Use ClioPatria release 3.1.1, support vanilla Docker builds

### DIFF
--- a/planner_reasoner/Dockerfile
+++ b/planner_reasoner/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 LABEL maintainer "leonid.mokrushin@ericsson.com"
 
-ARG PUBLIC_HOST
-ARG PUBLIC_PORT
-ARG PREFIX_PATH
-ARG EXPOSED_PREFIXES
+ARG PUBLIC_HOST=localhost
+ARG PUBLIC_PORT=3020
+ARG PREFIX_PATH=/
+ARG EXPOSED_PREFIXES=*
 
 WORKDIR /opt
 
@@ -13,7 +13,7 @@ COPY settings.db .
 
 RUN apt-get update && \
     apt-get -yq install git wget build-essential flex bison && \
-    git clone https://github.com/ClioPatria/ClioPatria.git && \
+    git clone -b 'V3.1.1' --depth 1 https://github.com/ClioPatria/ClioPatria.git && \
     git clone https://github.com/EricssonResearch/oslc_prolog.git && \
     git clone https://github.com/EricssonResearch/scott-eu.git && \
     git clone https://github.com/KCL-Planning/VAL.git && \

--- a/planner_reasoner/docker-compose.yml
+++ b/planner_reasoner/docker-compose.yml
@@ -1,14 +1,16 @@
 version: '2'
 services:
-  cliopatria:
+  planner_reasoner:
     build:
-      context: ./
+      context: .
       dockerfile: Dockerfile
       args:
-        - PUBLIC_HOST=localhost
-        - PUBLIC_PORT=3020
+        - PUBLIC_HOST=localhost # external host
+        - PUBLIC_PORT=3020 # external port
         - PREFIX_PATH=/
         - EXPOSED_PREFIXES=*
+    environment:
+      - PORT=3020 # internal port
     ports:
-      - "3020:3020"
+      - "3020:3020" # mapping of external port to internal port
     stdin_open: true


### PR DESCRIPTION
Now both `docker build` and `docker-compose build` are supported.
Downgraded ClioPatria to the latest release (V3.1.1) as some of the functionality got broken afterwards.